### PR TITLE
Up and Down Nephelios Commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +157,50 @@ name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
 
 [[package]]
 name = "bstr"
@@ -174,6 +239,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -249,6 +327,16 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
 
 [[package]]
 name = "difflib"
@@ -356,12 +444,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -369,6 +473,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -388,10 +520,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -422,13 +560,19 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap",
+ "http 0.2.12",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -443,10 +587,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -460,7 +621,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -487,8 +671,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -501,16 +685,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -654,12 +932,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -705,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linux-raw-sys"
@@ -792,8 +1082,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "bollard",
  "clap",
  "dotenv",
+ "futures",
+ "futures-util",
  "indicatif",
  "predicates",
  "reqwest",
@@ -806,6 +1099,12 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -935,6 +1234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,15 +1331,15 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1085,7 +1390,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1171,6 +1476,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1496,23 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.7.1",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -1214,9 +1547,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1302,6 +1635,57 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -1556,6 +1940,87 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bollard = "0.18.1"
 clap = { version = "4.4", features = ["derive"] }
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.0", features = ["full"] }
@@ -11,6 +12,8 @@ serde_json = "1.0"
 anyhow = "1.0"
 indicatif = "0.17"
 dotenv = "0.15"
+futures = "0.3.31"
+futures-util = "0.3.31"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/commands/down.rs
+++ b/src/commands/down.rs
@@ -1,0 +1,22 @@
+use crate::docker::nephelios_service::NepheliosService;
+use bollard::Docker;
+
+pub async fn execute() -> Result<(), anyhow::Error> {
+    let docker = Docker::connect_with_local_defaults();
+    match docker {
+        Ok(docker) => {
+            let nephelios_service: NepheliosService = NepheliosService::new(docker, vec![]);
+            match nephelios_service.stop().await {
+                Ok(_) => {
+                    println!("Nephelios stopped successfully");
+                    Ok(())
+                }
+                Err(e) => Err(e.into()),
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to connect to Docker: {}", e);
+            Err(e.into())
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,6 @@
 pub mod create;
+pub mod down;
 pub mod remove;
 pub mod start;
 pub mod stop;
+pub mod up;

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -1,0 +1,60 @@
+use crate::docker::nephelios_service::NepheliosService;
+use anyhow::Result;
+use bollard::Docker;
+
+pub async fn execute() -> Result<(), anyhow::Error> {
+    let docker = Docker::connect_with_local_defaults();
+    match docker {
+        Ok(docker) => {
+            let nephelios_service: NepheliosService = NepheliosService::new(docker, vec![]);
+
+            if !nephelios_service.is_nephelios_running().await {
+                if !nephelios_service.is_nephelios_stopped().await {
+                    let version: String = "latest".to_string();
+
+                    match nephelios_service.pull_image(version.clone()).await {
+                        Ok(_) => println!("Image {} pulled successfully", version),
+                        Err(e) => {
+                            eprintln!("Failed to pull image {}: {}", version, e);
+                            return Err(e.into());
+                        }
+                    }
+
+                    match nephelios_service.ensure_volumes().await {
+                        Ok(_) => println!("Volumes checked/created successfully"),
+                        Err(e) => {
+                            eprintln!("Failed to check/create volumes: {}", e);
+                            return Err(e.into());
+                        }
+                    }
+
+                    match nephelios_service.create(version.clone()).await {
+                        Ok(_) => println!("Nephelios started successfully"),
+                        Err(e) => {
+                            eprintln!("Failed to start Nephelios: {}", e);
+                            return Err(e.into());
+                        }
+                    }
+                }
+
+                println!("Nephelios is stopped, starting it up");
+
+                match nephelios_service.start().await {
+                    Ok(_) => println!("Nephelios started successfully"),
+                    Err(e) => {
+                        eprintln!("Failed to start Nephelios: {}", e);
+                        return Err(e.into());
+                    }
+                }
+            } else {
+                println!("Nephelios is already running");
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to connect to Docker: {}", e);
+            return Err(e.into());
+        }
+    }
+
+    Ok(())
+}

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,0 +1,2 @@
+pub mod nephelios_service;
+pub mod volumes;

--- a/src/docker/nephelios_service.rs
+++ b/src/docker/nephelios_service.rs
@@ -1,0 +1,218 @@
+use bollard::container::{
+    Config, CreateContainerOptions, ListContainersOptions, StartContainerOptions,
+};
+use bollard::image::CreateImageOptions;
+use bollard::Docker;
+use futures_util::stream::StreamExt;
+use std::collections::HashMap;
+use std::default::Default;
+use std::result::Result::Ok;
+
+use super::volumes::nephelios_volume::NepheliosVolume;
+
+pub struct NepheliosService {
+    pub docker: Docker,
+    pub name: String,
+    pub image: String,
+    pub socket: String,
+    pub volumes: Vec<NepheliosVolume>,
+}
+
+impl NepheliosService {
+    pub fn new(docker: Docker, volumes: Vec<NepheliosVolume>) -> Self {
+        Self {
+            docker,
+            name: "nephelios".to_string(),
+            image: "zuhowks/nephelios".to_string(),
+            socket: "/var/run/docker.sock".to_string(),
+            volumes: {
+                let volumes = vec![
+                    NepheliosVolume {
+                        name: "grafana_data",
+                        mount_path: "/var/lib/nephelios/grafana",
+                    },
+                    NepheliosVolume {
+                        name: "grafana_provisioning",
+                        mount_path: "/app/config/grafana",
+                    },
+                    NepheliosVolume {
+                        name: "grafana_dashboard",
+                        mount_path: "/app/config/dashboards",
+                    },
+                    NepheliosVolume {
+                        name: "prometheus_data",
+                        mount_path: "/app/prometheus",
+                    },
+                    NepheliosVolume {
+                        name: "registry_data",
+                        mount_path: "/var/lib/nephelios/registry",
+                    },
+                    NepheliosVolume {
+                        name: "nephelios_data",
+                        mount_path: "/app/config/prometheus",
+                    },
+                ];
+                volumes
+            },
+        }
+    }
+    pub fn get_label(&self) -> String {
+        format!("com.nephelios.name={}", self.name)
+    }
+
+    pub async fn start(&self) -> Result<(), anyhow::Error> {
+        let option = StartContainerOptions {
+            detach_keys: "ctrl-d",
+            ..Default::default()
+        };
+
+        let start_stream = self
+            .docker
+            .start_container(self.name.as_str(), Some(option));
+
+        start_stream
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to start container: {}", e))
+    }
+
+    pub async fn stop(&self) -> Result<(), anyhow::Error> {
+        self.docker
+            .stop_container(self.name.as_str(), None)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to stop container: {}", e))
+    }
+
+    async fn check_nephelios(&self, filters: HashMap<&str, Vec<&str>>) -> bool {
+        let options = Some(ListContainersOptions {
+            filters,
+            ..Default::default()
+        });
+
+        let containers = self.docker.list_containers(options).await;
+        match containers {
+            Ok(containers) => !containers.is_empty(),
+            Err(e) => {
+                eprintln!("Failed to list containers: {}", e);
+                false
+            }
+        }
+    }
+
+    pub async fn is_nephelios_running(&self) -> bool {
+        let label = self.get_label();
+        let mut filters: HashMap<&str, Vec<&str>> = HashMap::new();
+        filters.insert("status", vec!["running"]);
+        filters.insert("label", vec![label.as_str()]);
+        self.check_nephelios(filters).await
+    }
+
+    pub async fn is_nephelios_stopped(&self) -> bool {
+        let label = self.get_label();
+        let mut filters: HashMap<&str, Vec<&str>> = HashMap::new();
+        filters.insert("status", vec!["exited"]);
+        filters.insert("label", vec![label.as_str()]);
+        self.check_nephelios(filters).await
+    }
+
+    pub async fn pull_image(&self, version: String) -> Result<(), anyhow::Error> {
+        let image = format!("{}:{}", self.image, version);
+
+        let options = Some(CreateImageOptions {
+            from_image: image,
+            ..Default::default()
+        });
+
+        let mut create_stream = self.docker.create_image(options, None, None);
+
+        while let Some(output) = create_stream.next().await {
+            match output {
+                Ok(output) => {
+                    if let Some(stream) = output.progress {
+                        match serde_json::from_str::<serde_json::Value>(&stream) {
+                            Ok(value) => {
+                                if let Some(status) = value.get("status") {
+                                    println!("Pull Image info: {}", status);
+                                }
+                            }
+                            Err(_) => {
+                                println!("Pull Image info: {}", stream);
+                            }
+                        }
+                    }
+                    if let Some(error) = output.error {
+                        eprintln!("Error: {}", error);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Error pullings image: {}", e);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn create(&self, version: String) -> Result<(), anyhow::Error> {
+        let label = self.get_label();
+
+        let options = Some(CreateContainerOptions {
+            name: self.name.clone(),
+            platform: None,
+        });
+
+        let config = Config {
+            image: Some(format!("{}:{}", self.image, version)),
+            host_config: Some(bollard::service::HostConfig {
+                binds: Some({
+                    let mut binds = vec![];
+                    binds.push(format!("{}:/var/run/docker.sock", self.socket));
+                    for volume in &self.volumes {
+                        binds.push(format!("{}:{}", volume.name, volume.mount_path));
+                    }
+
+                    binds
+                }),
+                ..Default::default()
+            }),
+            labels: Some({
+                let mut labels = HashMap::new();
+
+                labels.insert("com.nephelios.name".to_string(), self.name.clone());
+                labels.insert(label.clone(), label);
+                labels
+            }),
+            ..Default::default()
+        };
+
+        let result: Result<bollard::secret::ContainerCreateResponse, bollard::errors::Error> =
+            self.docker.create_container(options, config).await;
+
+        match result {
+            Ok(res) => {
+                println!("Container {} created successfully", res.id);
+                Ok(())
+            }
+            Err(e) => {
+                eprintln!("Failed to create container: {}", e);
+                Err(e.into())
+            }
+        }
+    }
+
+    /// Ensures that all required Docker volumes exist for Nephelios.
+    /// If any volume doesn't exist, it will be created.
+    ///
+    /// # Returns
+    /// * `Ok(())` if all volumes were successfully checked/created
+    /// * `Err(String)` if there was an error during the process
+    pub async fn ensure_volumes(&self) -> Result<(), anyhow::Error> {
+        for volume in self.volumes.iter() {
+            if !(volume.is_volume_created(&self.docker).await) {
+                if !volume.create_volume(&self.docker).await {
+                    return Err(anyhow::anyhow!("Failed to create volume {}", volume.name));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/docker/volumes/mod.rs
+++ b/src/docker/volumes/mod.rs
@@ -1,0 +1,1 @@
+pub mod nephelios_volume;

--- a/src/docker/volumes/nephelios_volume.rs
+++ b/src/docker/volumes/nephelios_volume.rs
@@ -1,0 +1,52 @@
+use bollard::{volume::CreateVolumeOptions, Docker};
+use std::collections::HashMap;
+
+pub struct NepheliosVolume {
+    pub name: &'static str,
+    pub mount_path: &'static str,
+}
+
+impl NepheliosVolume {
+    pub fn new(name: &'static str, mount_path: &'static str) -> Self {
+        Self { name, mount_path }
+    }
+
+    pub async fn is_volume_created(&self, docker: &Docker) -> bool {
+        // Check if volume exists
+        let filters: HashMap<String, Vec<String>> = {
+            let mut map = HashMap::new();
+            map.insert("name".to_string(), vec![self.name.to_string()]);
+            map
+        };
+
+        let options = bollard::volume::ListVolumesOptions { filters };
+
+        let volumes = docker.list_volumes(Some(options)).await;
+
+        match volumes {
+            Ok(volumes) => volumes.volumes.is_some(),
+            Err(e) => {
+                eprintln!("Failed to list volumes: {}", e);
+                false
+            }
+        }
+    }
+
+    pub async fn create_volume(&self, docker: &Docker) -> bool {
+        let option = CreateVolumeOptions {
+            name: self.name.to_string(),
+
+            ..Default::default()
+        };
+
+        // Create volume
+        let result = docker.create_volume(option).await;
+        match result {
+            Ok(_) => true,
+            Err(e) => {
+                eprintln!("Failed to create volume {}: {}", self.name, e);
+                false
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod docker;
 mod types;
 mod utils;
 
@@ -23,26 +24,27 @@ async fn main() -> anyhow::Result<()> {
             github_url,
         } => {
             commands::create::execute(name, type_, github_url).await?;
-        },
+        }
 
-        Commands::Remove {
-            name,
-        } => {
+        Commands::Remove { name } => {
             commands::remove::execute(name).await?;
-        },
+        }
 
-        Commands::Stop {
-            name,
-        } => {
+        Commands::Stop { name } => {
             commands::stop::execute(name).await?;
-        },
+        }
 
-        Commands::Start {
-            name,
-        } => {
+        Commands::Start { name } => {
             commands::start::execute(name).await?;
         }
 
+        Commands::Up {} => {
+            commands::up::execute().await?;
+        }
+
+        Commands::Down {} => {
+            commands::down::execute().await?;
+        }
     }
 
     Ok(())

--- a/src/types/cli.rs
+++ b/src/types/cli.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 #[command(
     name = "nephelios-cli",
     author = "Your Name <your.email@example.com>",
-    version = "1.0.0",
+    version = env!("CARGO_PKG_VERSION"),
     about = "Nephelios CLI tool for managing application deployments",
     long_about = "A command-line interface for managing your Nephelios deployments. Supports creating new deployments, \
                   managing existing ones, and deploying applications from GitHub repositories."
@@ -55,23 +55,24 @@ pub enum Commands {
     /// This command deletes an existing application from the Nephelios platform.
     /// It requires the application name.
     Remove {
-
         /// Name of the application (e.g., my-awesome-app)
         #[arg(long, help = "Name of the application to remove")]
         name: String,
     },
 
     Start {
-
         /// Name of the application (e.g., my-awesome-app)
         #[arg(long, help = "Name of the application to start")]
         name: String,
     },
 
     Stop {
-
         /// Name of the application (e.g., my-awesome-app)
         #[arg(long, help = "Name of the application to stop")]
         name: String,
     },
+
+    Up {},
+
+    Down {},
 }


### PR DESCRIPTION
This pull request introduces several new features and improvements to the Nephelios CLI tool, primarily focused on Docker integration and command enhancements. The most significant changes include adding support for Docker operations, implementing new commands, and refactoring existing code to improve maintainability.

### Docker Integration:
* Added `bollard`, `futures`, and `futures-util` dependencies to `Cargo.toml` to support Docker operations.
* Created `NepheliosService` in `src/docker/nephelios_service.rs` to handle Docker container operations such as starting, stopping, pulling images, and ensuring volumes.
* Added `NepheliosVolume` in `src/docker/volumes/nephelios_volume.rs` to manage Docker volumes.

### New Commands:
* Added `up` and `down` commands in `src/commands/up.rs` and `src/commands/down.rs` respectively, to start and stop the Nephelios service using Docker. [[1]](diffhunk://#diff-c74d4dee452dbea455aaccb7f26752baa1961f254fb90b651704b31714bf92eeR1-R22) [[2]](diffhunk://#diff-5907a2d3818517e8e2f9619cd85b4578244a757255d6d6ce270f280ae35442a9R1-R60)
* Updated the command module to include the new `up` and `down` commands.
* Modified the CLI command definitions in `src/types/cli.rs` to include `Up` and `Down` commands.

### Code Refactoring:
* Updated `src/main.rs` to handle the new `up` and `down` commands in the main function.
* Changed the versioning in `src/types/cli.rs` to dynamically use the package version from `Cargo.toml`.

These changes significantly enhance the Nephelios CLI tool by integrating Docker support and adding new commands to manage the Nephelios service more effectively.