### PR TITLE
Fix Nephelios Container didn't exposed on Host

### DIFF
--- a/src/commands/down.rs
+++ b/src/commands/down.rs
@@ -5,7 +5,7 @@ pub async fn execute() -> Result<(), anyhow::Error> {
     let docker = Docker::connect_with_local_defaults();
     match docker {
         Ok(docker) => {
-            let nephelios_service: NepheliosService = NepheliosService::new(docker, vec![]);
+            let nephelios_service: NepheliosService = NepheliosService::new(docker, None, None);
             match nephelios_service.stop().await {
                 Ok(_) => {
                     println!("Nephelios stopped successfully");

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::docker::nephelios_service::NepheliosService;
 use anyhow::Result;
 use bollard::Docker;
@@ -6,7 +8,8 @@ pub async fn execute() -> Result<(), anyhow::Error> {
     let docker = Docker::connect_with_local_defaults();
     match docker {
         Ok(docker) => {
-            let nephelios_service: NepheliosService = NepheliosService::new(docker, vec![]);
+            let nephelios_service: NepheliosService =
+                NepheliosService::new(docker, Some("3030/tcp".to_string()), Some(HashMap::new()));
 
             if !nephelios_service.is_nephelios_running().await {
                 if !nephelios_service.is_nephelios_stopped().await {

--- a/src/docker/nephelios_service.rs
+++ b/src/docker/nephelios_service.rs
@@ -200,6 +200,17 @@ impl NepheliosService {
 
                     binds
                 }),
+                port_bindings: Some({
+                    let mut port_bindings = HashMap::new();
+                    port_bindings.insert(
+                        self.exposed_port.clone(),
+                        Some(vec![bollard::service::PortBinding {
+                            host_ip: Some("0.0.0.0".to_string()),
+                            host_port: Some(self.exposed_port.clone()),
+                        }]),
+                    );
+                    port_bindings
+                }),
                 ..Default::default()
             }),
             labels: Some({
@@ -210,7 +221,10 @@ impl NepheliosService {
                 labels
             }),
             env: Some(self.env.clone()),
-            exposed_ports: Some(HashMap::from([(self.exposed_port.clone(), HashMap::new())])),
+            exposed_ports: Some(HashMap::from([
+                (format!("{}/tcp", self.exposed_port.clone()), HashMap::new()),
+                (format!("{}/udp", self.exposed_port.clone()), HashMap::new()),
+            ])),
             ..Default::default()
         };
 


### PR DESCRIPTION
This pull request includes several important changes to the `NepheliosService` implementation and its usage in the `up` and `down` commands. The changes aim to enhance the configuration flexibility of the service by introducing options for exposed ports and environment variables.

Enhancements to `NepheliosService`:

* [`src/docker/nephelios_service.rs`](diffhunk://#diff-be13f4f07e7ac5f8d6e8c85337873e673299865ede1cd8ea50dca89ae387106fR19-R29): Added `exposed_port` and `env` fields to the `NepheliosService` struct. Modified the `new` method to accept optional parameters for exposed port and environment variables, and updated the implementation to use these parameters. [[1]](diffhunk://#diff-be13f4f07e7ac5f8d6e8c85337873e673299865ede1cd8ea50dca89ae387106fR19-R29) [[2]](diffhunk://#diff-be13f4f07e7ac5f8d6e8c85337873e673299865ede1cd8ea50dca89ae387106fR64-R85)
* [`src/docker/nephelios_service.rs`](diffhunk://#diff-be13f4f07e7ac5f8d6e8c85337873e673299865ede1cd8ea50dca89ae387106fR203-R213): Updated the `create_container_config` method to configure port bindings, environment variables, and exposed ports based on the new fields. [[1]](diffhunk://#diff-be13f4f07e7ac5f8d6e8c85337873e673299865ede1cd8ea50dca89ae387106fR203-R213) [[2]](diffhunk://#diff-be13f4f07e7ac5f8d6e8c85337873e673299865ede1cd8ea50dca89ae387106fR223-R227)

Changes in `up` and `down` commands:

* [`src/commands/up.rs`](diffhunk://#diff-5907a2d3818517e8e2f9619cd85b4578244a757255d6d6ce270f280ae35442a9R1-R2): Updated the `execute` function to pass the new parameters to `NepheliosService::new`. [[1]](diffhunk://#diff-5907a2d3818517e8e2f9619cd85b4578244a757255d6d6ce270f280ae35442a9R1-R2) [[2]](diffhunk://#diff-5907a2d3818517e8e2f9619cd85b4578244a757255d6d6ce270f280ae35442a9L9-R12)
* [`src/commands/down.rs`](diffhunk://#diff-c74d4dee452dbea455aaccb7f26752baa1961f254fb90b651704b31714bf92eeL8-R8): Updated the `execute` function to match the new `NepheliosService::new` signature.